### PR TITLE
Add test ground binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 ## vscode local history
 .history/
 
+# Test ground should be local to every developer
+src/test_ground/
 
 ## dev
 InstanceTest/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,20 @@ exclude = [
     "InstanceTest/*"
 ]
 
+[[bin]]
+name = "test_ground"
+path = "src/test_ground/main.rs"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 minreq = { version = "2.4.2", features = ["punycode","https-rustls-probe"] }
 serde = { version = "1.0", features = ["derive"] }
+# erased-serde = "0.3"
 chashmap = "2.2.2"
 regex = "1.5.4"
 

--- a/src/test_ground/main.rs
+++ b/src/test_ground/main.rs
@@ -1,0 +1,5 @@
+use rocket::tokio;
+#[tokio::main]
+async fn main () {
+    println!("This is the test ground binary for Lodestone, put any code you want to test here");
+}


### PR DESCRIPTION
`test_ground` binary is a separate binary from the main binary. This allows the developer to put any code/module they want to test in the binary without containmenting the main binary.