### PR TITLE
make vendored openssl build optional via a feature flag

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target ${{ matrix.platform }}
+          args: --release --features "vendored-openssl" --target ${{ matrix.platform }}
 
       # on windows it's ./target/release/main.exe
       # on linux it's ./target/release/main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ ts-rs = "6.2.1"
 walkdir = "2.3.2"
 whoami = "1.2.3"
 zip = "0.6.2"
-openssl = { version = "0.10.45", features = ["vendored"] }
+openssl = { version = "0.10.45", features = ["vendored"], optional = true }
 flate2 = "1.0.24"
 tar = "0.4.38"
 unrar = "0.4.4"
@@ -95,3 +95,6 @@ features = [
     "fast-rng",          # Use a faster (but still sufficiently random) RNG
     "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
 ]
+
+[features]
+vendored-openssl = ["dep:openssl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY . ./
 
 # build app using 'release' profile
-RUN cargo build --release
+RUN cargo build --release --features "vendored-openssl"
 
 FROM debian:bullseye-slim as production
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add feature flag `vendored-openssl` to statically link an ssl library or not (turning on the flag will make it statically link).


## Type of change

<!-- Please put 'x' next to the type of change you are making.
Ex.
- [x] Bug fix (non-breaking change which fixes an issue) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

*Note: make sure your files are formatted with rust-analyzer*