### PR TITLE
Fix Docker Mount Point Permission Errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY --from=build /app/target/release/main ./
 # specify default port
 EXPOSE 16662
 
-RUN groupadd -r user && useradd -r -g user user
+RUN groupadd user && useradd -g user user
 
 RUN mkdir -p /home/user/.lodestone
 RUN chown user /app

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ docker run -d \
   --name lodestone \
   --restart unless-stopped \
   -p 16662:16662 \
-  -v lodestone:/root/.lodestone \
-  ghcr.io/Lodestone-Team/lodestone_core
+  -v lodestone:/home/user/.lodestone \
+  ghcr.io/lodestone-team/lodestone_core
 ```
 
 <!-- GETTING STARTED -->

--- a/githubactions.Dockerfile
+++ b/githubactions.Dockerfile
@@ -30,7 +30,7 @@ EXPOSE 16662
 
 RUN chmod +x ./main
 
-RUN groupadd -r user && useradd -r -g user user
+RUN groupadd user && useradd -g user user
 
 RUN mkdir -p /home/user/.lodestone
 RUN chown user /app


### PR DESCRIPTION
# Description

The docker container had permission errors when running using a mount point, and setting UID and GID with `--user` did not resolve it. Changing the user to a non-system user seems to fix both issues. Also updates the readme to use the correct docker commands.



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update