### PR TITLE
Add docker compose as installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,15 @@ docker run -d \
 ```
 Docker Compose example:
 
-Download the docker-compose.yml file from this repo using 
+Download the docker-compose.yml file from this repo using
+```sh
+wget https://raw.githubusercontent.com/Lodestone-Team/lodestone_core/main/docker-compose.yml
+```
+and then run it using
+```sh
+docker compose up -d
+```
+Alternatively, create docker-compose.yml yourself:
 ```yml
 version: '3.8'
 services:
@@ -110,11 +118,6 @@ services:
 volumes:
   lodestone:
 ```
-Copy into docker-compose.yml and run
-```sh
-docker compose up -d
-```
-Alternatively, 
 
 <!-- GETTING STARTED -->
 ## Getting Started (development)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Alternatively, you may build your own image using the default `Dockerfile`, not 
 > You may add additional ports as you wish to forward, but 16662 is the default port served in the image.
 > You may add a volume for your lodestone instance to be accessible, in the example below, you can create a volume first by using `docker volume create lodestone`.
 
-To use:
+Docker CLI example:
 ```sh
 docker run -d \
   --name lodestone \
@@ -92,6 +92,29 @@ docker run -d \
   -v lodestone:/home/user/.lodestone \
   ghcr.io/lodestone-team/lodestone_core
 ```
+Docker Compose example:
+
+Download the docker-compose.yml file from this repo using 
+```yml
+version: '3.8'
+services:
+  lodestone:
+    container_name: lodestone
+    image: ghcr.io/lodestone-team/lodestone_core
+    restart: unless-stopped
+    ports:
+      - "16662:16662"
+    volumes:
+      - lodestone:/home/user/.lodestone
+
+volumes:
+  lodestone:
+```
+Copy into docker-compose.yml and run
+```sh
+docker compose up -d
+```
+Alternatively, 
 
 <!-- GETTING STARTED -->
 ## Getting Started (development)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  lodestone:
+    container_name: lodestone
+    image: ghcr.io/lodestone-team/lodestone_core
+    restart: unless-stopped
+    ports:
+      - "16662:16662"
+    volumes:
+      - lodestone:/home/user/.lodestone
+
+volumes:
+  lodestone:


### PR DESCRIPTION
# Description

Adds an example on how to install lodestone-core using the docker package with docker compose.
Adds a docker-compose.yml file with an example on how to install using docker compose.

## Type of change
- [x] Documentation update